### PR TITLE
Count arriving flights

### DIFF
--- a/src/components/map/airports/MapAirportsList.vue
+++ b/src/components/map/airports/MapAirportsList.vue
@@ -276,10 +276,23 @@ const getAirportsList = computed(() => {
         if (!foundAirports.length) continue;
 
         for (const airport of foundAirports) {
-            if (airport.aircraftList.departures?.includes(pilot.cid) && !airport.aircraft.departures) airport.aircraft.departures = true;
-            if (airport.aircraftList.arrivals?.includes(pilot.cid) && !airport.aircraft.arrivals) airport.aircraft.arrivals = true;
-
-            if (airport.aircraftList.groundArr?.includes(pilot.cid)) {
+            if (airport.aircraftList.departures?.includes(pilot.cid)) {
+                if (!airport.aircraft.departures) {
+                    airport.aircraft.departures = [pilot];
+                }
+                else {
+                    (airport.aircraft.departures as VatsimShortenedAircraft[]).push(pilot);
+                }
+            }
+            else if (airport.aircraftList.arrivals?.includes(pilot.cid)) {
+                if (!airport.aircraft.arrivals) {
+                    airport.aircraft.arrivals = [pilot];
+                }
+                else {
+                    (airport.aircraft.arrivals as VatsimShortenedAircraft[]).push(pilot);
+                }
+            }
+            else if (airport.aircraftList.groundArr?.includes(pilot.cid)) {
                 if (!airport.aircraft.groundArr) {
                     airport.aircraft.groundArr = [pilot];
                 }
@@ -287,8 +300,7 @@ const getAirportsList = computed(() => {
                     (airport.aircraft.groundArr as VatsimShortenedAircraft[]).push(pilot);
                 }
             }
-
-            if (airport.aircraftList.groundDep?.includes(pilot.cid)) {
+            else if (airport.aircraftList.groundDep?.includes(pilot.cid)) {
                 if (!airport.aircraft.groundDep) {
                     airport.aircraft.groundDep = [pilot];
                 }

--- a/src/components/map/filters/MapFilters.vue
+++ b/src/components/map/filters/MapFilters.vue
@@ -118,6 +118,49 @@
                         />
                     </common-control-block>
                 </div>
+                <div
+                    class="filters__option"
+                    :class="{ 'filters_sections_section--selected': selectedFilter === 'setting' }"
+                    @click="selectedFilter = 'setting'"
+                >
+                    <common-button type="secondary">
+                        <template #icon>
+                            <settings-icon/>
+                        </template>
+                    </common-button>
+                    <common-control-block
+                        center-by="start"
+                        class="filters_sections_section_content"
+                        location="right"
+                        :model-value="selectedFilter === 'setting'"
+                        @update:modelValue="!$event ? selectedFilter = null : undefined"
+                    >
+                        <template #title>
+                            Options
+                        </template>
+                        <div
+                            class="filters_toggle"
+                        >
+                            <common-toggle
+                                :model-value="store.localSettings.filters?.options?.countArrivingFlights || false"
+                                @update:modelValue="setUserLocalSettings( { filters: { options: { countArrivingFlights: $event } } }  )"
+                            >
+                                <common-tooltip
+                                    location="bottom"
+                                    width="200px"
+                                >
+                                    <template #activator>
+                                        <div class="filters__option_question">
+                                            Count arriving flights
+                                            <question-icon width="14"/>
+                                        </div>
+                                    </template>
+                                    Enabling this will show the count of the not yet arrived flights as the red number next to the airport icao code on the map instead of showing the count of the already landed flights.
+                                </common-tooltip>
+                            </common-toggle>
+                        </div>
+                    </common-control-block>
+                </div>
             </div>
         </transition>
     </div>
@@ -127,6 +170,7 @@
 import FilterIcon from '@/assets/icons/kit/filter.svg?component';
 import MapIcon from '@/assets/icons/kit/map.svg?component';
 import GroundIcon from '@/assets/icons/kit/mountains.svg?component';
+import SettingsIcon from '@/assets/icons/kit/settings.svg?component';
 import CommonButton from '~/components/common/basic/CommonButton.vue';
 import { useStore } from '~/store';
 import CommonControlBlock from '~/components/common/blocks/CommonControlBlock.vue';
@@ -140,6 +184,8 @@ import type {
 import MapFilterTransparency from '~/components/map/filters/MapFilterTransparency.vue';
 import CommonBlockTitle from '~/components/common/blocks/CommonBlockTitle.vue';
 import CommonToggle from '~/components/common/basic/CommonToggle.vue';
+import CommonTooltip from '~/components/common/basic/CommonTooltip.vue';
+import QuestionIcon from 'assets/icons/basic/question.svg?component';
 
 const store = useStore();
 
@@ -306,6 +352,14 @@ const weatherLayers: RadioItemGroup<MapWeatherLayer | 'false'>[] = [
 
         &_image {
             max-width: 40%;
+        }
+    }
+
+    &__option {
+        &_question {
+            display: flex;
+            gap: 4px;
+            align-items: center;
         }
     }
 }

--- a/src/types/map.ts
+++ b/src/types/map.ts
@@ -20,8 +20,7 @@ export type MapAircraftKeys = keyof MapAirport['aircraft'];
 export type MapAircraftMode = 'all' | 'ground' | MapAircraftKeys;
 
 export type MapAircraft =
-    PartialRecord<keyof Pick<MapAirport['aircraft'], 'groundDep' | 'groundArr' | 'prefiles'>, VatsimShortenedPrefile[]>
-    & PartialRecord<keyof Pick<MapAirport['aircraft'], 'departures' | 'arrivals'>, boolean>;
+    PartialRecord<keyof Pick<MapAirport['aircraft'], 'groundDep' | 'groundArr' | 'prefiles' | 'departures' | 'arrivals'>, VatsimShortenedPrefile[]>;
 
 export type MapWeatherLayer = 'PR0' | 'WND' | 'CL' | 'rainViewer';
 export type MapLayoutLayerExternal = 'OSM' | 'Satellite' | 'Jawg' | 'CartoDB' | 'CartoDBLabels';
@@ -47,6 +46,9 @@ interface IUserLocalSettings {
             weather2?: MapWeatherLayer | false;
             layer?: MapLayoutLayerWithOptions;
             transparencySettings?: UserLayersTransparencySettings;
+        };
+        options?: {
+            countArrivingFlights?: boolean;
         };
     };
 }


### PR DESCRIPTION
### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #117-->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [x] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

It is an option to show the count of not yet arrived aircrafts next to the icao code on the map instead of the count of the already landed aircrafts. By default it is off.

Currently the setting is an UserLocalSettings, it was easier for development. But i think it might be better an UserSettings.
