### PR TITLE
Fixed issue #305 - "Time Online not displayed when TRACON/Center ATIS…

### DIFF
--- a/src/components/common/vatsim/CommonControllerInfo.vue
+++ b/src/components/common/vatsim/CommonControllerInfo.vue
@@ -73,10 +73,7 @@
                             {{ item }}
                         </template>
                     </template>
-                    <template
-                        v-if="showAtis && controller.text_atis?.length"
-                        #bottom
-                    >
+                    <template #bottom>
                         <ul class="atc-popup_atc__atis">
                             <li
                                 v-for="atis in getATIS(controller)"


### PR DESCRIPTION
Fixed #305 

### 🔗 Your VATSIM ID

1841086

### 🔗 Linked Issue

https://github.com/VATSIM-Radar/vatsim-radar/issues/305

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [x] 🐞 Bug fix
- [ ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

Time online was set to be displayed only when controlled had atis text. Changed to be displayed for any controller.
