### PR TITLE
Fixed unreliable center label popup

### DIFF
--- a/src/components/map/MapOverlay.vue
+++ b/src/components/map/MapOverlay.vue
@@ -154,8 +154,7 @@ watch([model, popup, openOverlayId], async ([, popupVal], [, oldPopupVal, oldOve
     }
 
     if (!oldPopupVal && popupVal && oldOverlayId !== popupId) {
-        if (mapStore.openOverlayId && mapStore.openOverlayId && mapStore.openOverlayId !== popupId) return;
-
+        // if (mapStore.openOverlayId && mapStore.openOverlayId && mapStore.openOverlayId !== popupId) return;
         mapStore.openOverlayId = popupId;
     }
     else if (popup.value && mapStore.openOverlayId !== popupId) {


### PR DESCRIPTION
When you hover over an aircraft icon and move your mouse fast over a center label, the center label popup is not opening.
With the now disabled line the center label popup works.
Has to be tested after v1 release if it breaks something else.
