### PR TITLE
Update atc-duplicating.ts to add CLT_APP

### DIFF
--- a/app/utils/server/vatsim/atc-duplicating.ts
+++ b/app/utils/server/vatsim/atc-duplicating.ts
@@ -145,6 +145,7 @@ export const duplicatingSettings = [
         suffixes: ['CTR', 'APP', 'DEP'],
         mapping: {
             AGS: 'AGS_APP',
+            CLT: 'CLT_APP',
             GSO: 'GSO_APP',
             AHN: 'AHN_APP',
             CSG: 'CSG_APP',


### PR DESCRIPTION

### 🔗 Your VATSIM ID

1712777

### 🔗 Linked Issue

<!-- If your PR has an issue, please specify it like Closes #123 -->

### ❓ Type of change

<!-- What are you changing? Please put an `x` in all `[ ]` below that match your PR purpose. -->

- [ ] 🐞 Bug fix
- [x ] 👌 Enhancement (improve something existing)
- [ ] ✨ New functionality
- [ ] 🧹 Technical change (refactoring, updates and other improvements)

### 📚 Description

<!-- Tell us more about your PR -->
Adds CLT_APP to extended frequencies. There is a small portion that extends out of the ZTL borders.